### PR TITLE
Allow line render in scene with no camera

### DIFF
--- a/addons/LineRenderer/line_renderer.gd
+++ b/addons/LineRenderer/line_renderer.gd
@@ -33,7 +33,11 @@ func _process(_delta):
 	if points.size() < 2:
 		return
 	
-	camera = get_viewport().get_camera_3d()
+	if Engine.is_editor_hint():
+		camera = Engine.get_singleton("EditorInterface").get_editor_viewport_3d(0).get_camera_3d()
+	else:
+		camera = get_viewport().get_camera_3d()
+	
 	if camera == null:
 		return
 	cameraOrigin = to_local(camera.get_global_transform().origin)


### PR DESCRIPTION
This code allows the line to be rendered even if there is no camera in the scene (in this case, it will be the camera used to see the scene that will be rendered). This code is working fine even in build.